### PR TITLE
Update .gitmodules to fix error when cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "gslpp"]
 	path = gslpp
 	url = https://github.com/silvest/gslpp.git
-[submodule "RGESolver/gslpp"]
-	path = gslpp
-	url = https://github.com/silvest/gslpp.git


### PR DESCRIPTION
The gslpp submodule was defined twice in the .gitmodules. Fix applied.